### PR TITLE
Image can be any size and in .png and .jpg format

### DIFF
--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -104,7 +104,7 @@
                 $(":file").filestyle({icon: false, placeholder: "No file chosen"});
             .col-md-6
               = submit_tag(_("Upload"), :id => "upload", :class => "upload btn btn-default")
-              = _('* Requirements: File-type - PNG; Dimensions - 350x70.')
+              = _('* Requires image file in .png or .jpg format')
     - if @record.display && !@record.prov_type.try(:start_with?, "generic_")
       = miq_tab_content('details') do
         %h3


### PR DESCRIPTION
Fixes the description on the image upload as it does not need to be 350x70 pixels and can be in either .png or .jpg format. 

https://bugzilla.redhat.com/show_bug.cgi?id=1354026