### PR TITLE
Fix typo and update for RHEV name change (Take 2)

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -3,7 +3,7 @@ class ServiceTemplate < ApplicationRecord
 
   GENERIC_ITEM_SUBTYPES = {
     "custom"          => _("Custom"),
-    "vm"              => _("VM"),
+    "vm"              => _("Virtual Machine"),
     "playbook"        => _("Playbook"),
     "hosted_database" => _("Hosted Database"),
     "load_balancer"   => _("Load Balancer"),
@@ -16,12 +16,12 @@ class ServiceTemplate < ApplicationRecord
     "generic"                    => _("Generic"),
     "generic_orchestration"      => _("Orchestration"),
     "generic_ansible_playbook"   => _("Ansible Playbook"),
-    "generic_ansible_tower"      => _("AnsibleTower"),
+    "generic_ansible_tower"      => _("Ansible Tower"),
     "generic_container_template" => _("OpenShift Template"),
     "google"                     => _("Google"),
     "microsoft"                  => _("SCVMM"),
     "openstack"                  => _("OpenStack"),
-    "redhat"                     => _("RHEV"),
+    "redhat"                     => _("Red Hat Virtualization"),
     "vmware"                     => _("VMware")
   }.freeze
 


### PR DESCRIPTION
Redo of https://github.com/ManageIQ/manageiq/pull/16565

Changes:
Updated dialog text to make"AnsibleTower" two words
Change RHEV to the new name Red Hat "Virtualization"
Change "VM" to "Virtual Machine" for clarity

Corresponding BZ https://bugzilla.redhat.com/show_bug.cgi?id=1519316

"Red Hat® Virtualization (formerly Red Hat Enterprise Virtualization)—powered by the people behind Red Hat Enterprise Linux®"
From: https://www.redhat.com/en/technologies/virtualization